### PR TITLE
NumberFormatException Example,

### DIFF
--- a/src/main/java/com/gowri/tech/exceptns/ArrayIndexOutExample1.java
+++ b/src/main/java/com/gowri/tech/exceptns/ArrayIndexOutExample1.java
@@ -9,8 +9,6 @@ public class ArrayIndexOutExample1 {
 
         public static void main(String[] args)
         {
-
-            // taking array of integers
             int a[] = { 1, 2, 3, 4, 5 };
 
             for (int i = 0; i <= a.length; i++)

--- a/src/main/java/com/gowri/tech/exceptns/NumberFormatEx.java
+++ b/src/main/java/com/gowri/tech/exceptns/NumberFormatEx.java
@@ -1,0 +1,20 @@
+package com.gowri.tech.exceptns;
+/*
+ * @author NaveenWodeyar
+ * @date 20-01-2025
+ */
+
+public class NumberFormatEx {
+
+    public static void numberFormatExcptn(String st){
+        Integer i = Integer.parseInt(st);
+        System.out.println(i);
+    }
+
+    public static void main(String[] args) {
+        String arg = args[0];
+        Integer i = Integer.parseInt(arg);
+        numberFormatExcptn(String.valueOf(i));
+        System.out.println(i);
+    }
+}


### PR DESCRIPTION
NumberFormatException is thrown when an attempt is made to convert a string into a numeric type (such as int, double, float, long, etc.), but the string does not have an appropriate format.